### PR TITLE
fix: 限制 ``` 代码块检测仅在行首生效

### DIFF
--- a/main.py
+++ b/main.py
@@ -415,7 +415,7 @@ class MessageSplitterPlugin(Star):
         ratio_max = self._get_cfg("balanced_split_ratio_max", 0.9)
         
         while i < n:
-            if text.startswith("```", i):
+            if text.startswith("```", i) and (i == 0 or text[i-1] == chr(10)):
                 idx = text.find("```", i + 3)
                 if idx != -1: chunk += text[i:idx+3]; weight += idx+3-i; i = idx+3; continue
                 else: chunk += text[i:]; weight += n-i; break


### PR DESCRIPTION
## 问题                                                                                                          
 `_process_text_smart()` 中对 ` ``` ` 的检测 `text.startswith("```", i)`
没有位置限制。当 LLM 输出中包含行内 ` ``` ` 字面量（例如在解释 markdown
语法时写的「请用 ``` 包裹」），splitter 会将其误判为代码块起始标记。

随后 `text.find("```", i + 3)` 搜索下一个 ` ``` ` 时：
- 若全文没有第二个 ` ``` ` → 剩余全部文本被当作代码块吞入，**整个消息不再分段**
- 若后面还有真正的代码块 ` ``` ` → 中间所有段落被错误合并进代码块

## 修复

```python
# 改前
if text.startswith("```", i):

# 改后
if text.startswith("```", i) and (i == 0 or text[i-1] == chr(10)):

要求 ``` 必须在行首才能被识别为代码块分隔符，与标准 markdown 代码围栏语法一致。

验证

复现场景：bot 输出包含「颜文字请用 ``` 包裹」等行内 ``` 说明文字。
改前消息不分段，改后正常切分。
```
